### PR TITLE
Add Python-based ParaPower version

### DIFF
--- a/APIs/ParaPower/ParaPowerAPI.py
+++ b/APIs/ParaPower/ParaPowerAPI.py
@@ -1,5 +1,13 @@
 import numpy as np
 import json
+import sys
+from core.PSCore import PSCore
+
+PPPY_PATH = PSCore.PPPythonSrc
+if PPPY_PATH not in sys.path:
+    sys.path.insert(0, PPPY_PATH)
+
+from main import ParaPowerSynth  # preferred when PPPythonSrc is on sys.path
 
 class Params(object):
     """The :class:`Params` object contains attributes that are used in the solver setting of ParaPower.
@@ -133,13 +141,14 @@ class ParaPowerInterface(object):
 
     """
     def __init__(self, external_conditions=ExternalConditions(), parameters=Params(), features=None
-                 ,pp_json_path=None,solution_name='PSData',matlab_engine=None):
+                 ,pp_json_path=None,solution_name='PSData',matlab_engine=None, use_matlab = True):
         self.ExternalConditions = external_conditions
         self.Params = parameters
         self.Features = features
         self.PottingMaterial = 0
         self.temperature = None
         self.matlab_engine = matlab_engine
+        self.use_matlab = use_matlab
         self.path = pp_json_path
         self.solution_name = solution_name
         self.save_parapower()
@@ -177,17 +186,22 @@ class ParaPowerInterface(object):
         :rtype temperature: float
         """
 
-        if self.matlab_engine == None:
+        md_json = json.dumps(self.to_dict())
+        temperature = 5
+
+        if self.matlab_engine == None and self.use_matlab:
             if matlab_engine == None:
                 raise Exception("Failed to start new MATLAB engine")
             else:
                 self.matlab_engine = matlab_engine
-        md_json = json.dumps(self.to_dict())
+                results = self.matlab_engine.ParaPowerSynth(md_json, 'thermal', 'static', 'global')
+                temperature = {'D1':results['temperature'][-1]+273.5}
+        else:
+            results = ParaPowerSynth(md_json, 'thermal', 'static', 'global')
+            temperature = {'D1': results[-1] + 273.5}
+
         # temperature = matlab_engine.PowerSynthImport_V2(md_json)
-        temperature = 5
-        results = self.matlab_engine.ParaPowerSynth(md_json, 'thermal', 'static', 'global')
         #results_full = self.matlab_engine.ParaPowerSynth(md_json, 'thermal', 'static', 'individual')
-        results = json.loads(results)
         #results_full = json.loads(results_full)
         #print(results)
         '''temperature_dict = {}
@@ -197,7 +211,6 @@ class ParaPowerInterface(object):
                 temperature_dict[name] = f['temperature'][-1] + 273.5'''
                 
 
-        temperature = {'D1':results['temperature'][-1]+273.5}
         # self.eng.workspace['test_md'] = self.eng.ImportPSModuleDesign(json.dumps(self.to_dict()), nargout=1)
         # self.eng.save('test_md_file.mat', 'test_md')
         # return temperature + 273.5
@@ -241,7 +254,7 @@ class ParaPowerWrapper(object):
 
     """
 
-    def __init__(self, solution,t_amb=None,h_val=None,matlab_engine=None,pp_json_path=None):
+    def __init__(self, solution,t_amb=None,h_val=None,matlab_engine=None,pp_json_path=None, use_matlab = True):
         self.c2k = 273.5
         self.solution = solution
         self.ref_locs = np.array([0,0,0])
@@ -265,7 +278,8 @@ class ParaPowerWrapper(object):
 
         self.parapower = ParaPowerInterface(self.external_conditions.to_dict(),
                                             self.parameters.to_dict(),
-                                            self.features,pp_json_path=self.pp_json_path,matlab_engine=matlab_engine)
+                                            self.features,pp_json_path=self.pp_json_path,matlab_engine=matlab_engine,
+                                            use_matlab=use_matlab)
         # self.output = PPEncoder().encode(self.parapower)
         # self.write_md_output()
     def get_features(self):

--- a/CmdRun/CmdHandler.py
+++ b/CmdRun/CmdHandler.py
@@ -235,6 +235,8 @@ class CmdHandler:
                         if info[0] == 'Simulator:':
                             self.export_ansys_em_info['simulator'] = int(info[1])
                     if(self.thermal_mode): # Get info for thermal setup
+                        if info[0] == 'Use_MATLAB:':
+                            self.thermal_models_info["use_matlab"] = int(info[1])
                         if info[0] == 'Model_Select:':
                             self.thermal_models_info['model'] = int(info[1])
                         if info[0] == 'Measure_Name:' and t_name==None:
@@ -821,6 +823,7 @@ class CmdHandler:
         self.t_api = CornerStitch_Tmodel_API(comp_dict=self.layout_obj_dict)
         self.t_api.pp_json_path=self.PSCore.PPDir
         self.t_api.layer_stack=self.layer_stack
+        self.t_api.use_matlab = bool(self.thermal_models_info.get("use_matlab", 1))
         #print("PP_FOLDER",self.t_api.pp_json_path)
         if mode == 'command':
             self.measures += self.t_api.measurement_setup()
@@ -834,7 +837,7 @@ class CmdHandler:
             self.t_api.model=model_type
             if model_type == 0: # Select TSFM model
                 self.t_api.characterize_with_gmsh_and_elmer()
-            if model_type==2:
+            if model_type==2 and self.thermal_models_info["use_matlab"] == 1:
                 self.t_api.init_matlab()
 
     def init_apis(self):

--- a/PSCore.py
+++ b/PSCore.py
@@ -49,6 +49,7 @@ class PSEnv():
         FHExe+=".exe"
 
     PPSrc = os.path.join(PSRoot,'pkg','lib','ParaPower')
+    PPPythonSrc = os.path.join(PSRoot,'pkg','lib','ParaPowerPython')
     ManPDF = os.path.join(PSRoot,'pkg','man',f'PowerSynth_v{PSVers}.pdf')
 
     DebugLv=0

--- a/model/thermal/cornerstitch_API.py
+++ b/model/thermal/cornerstitch_API.py
@@ -57,6 +57,7 @@ class CornerStitch_Tmodel_API:
         self.pp_json_path= None # to store PP json file
         self.ppw=None
         self.pLoss ={}
+        self.use_matlab = True
         # print("Starting cornerstitch_API thermal interface")
 
     def init_matlab(self):
@@ -133,14 +134,20 @@ class CornerStitch_Tmodel_API:
             self.temp_res = {}
             if len(h_val)==1:
                 h_val.append(0) # single-sided cooling
-            if self.matlab_engine != None:
-                if self.ppw is None:
-                    print("INFO: Running ParaPower: "+self.pp_json_path,flush=True)
-                self.ppw = pp.ParaPowerWrapper(solution,ambient_temp,h_val,self.matlab_engine,self.pp_json_path)
-            else:
-                print("Matlab engine not started")
-            self.temp_res = self.ppw.parapower.run_parapower_thermal(matlab_engine=self.matlab_engine)
             
+            if self.ppw is None:
+                if self.use_matlab:
+                    print("INFO: Running ParaPower in MATLAB: "+self.pp_json_path,flush=True)
+                else:
+                    print("INFO: Running ParaPower in Python: "+self.pp_json_path,flush=True)
+
+            self.ppw = pp.ParaPowerWrapper(solution, ambient_temp, h_val,
+                                        self.matlab_engine,
+                                        self.pp_json_path,
+                                        self.use_matlab)
+            
+            self.temp_res = self.ppw.parapower.run_parapower_thermal(matlab_engine=self.matlab_engine)
+                
             return
     
 


### PR DESCRIPTION
Added self.use_matlab flag which is read from the macro scripts to decide which solver (MATLAB or Python-based) is used. Also added a path to PSCore to the Python-based engine. Related to Issue https://github.com/e3da/PowerSynth2-pkg/issues/11